### PR TITLE
increase timeout to 1 seconds in unit tests

### DIFF
--- a/pkg/system/relay_test.go
+++ b/pkg/system/relay_test.go
@@ -231,7 +231,7 @@ func TestAbleToRelayMessagesAfterCrash(t *testing.T) {
 			}
 		}()
 
-		time.Sleep(100 * time.Millisecond)
+		time.Sleep(time.Second)
 		for _, msg := range expectedData {
 			pushChannel <- msg
 		}


### PR DESCRIPTION
increase timeout to 1 seconds since we do not wait for fd_socket in unit tests