### PR TITLE
Arm64 assembly conversion

### DIFF
--- a/GENESIS_RESULT/README.md
+++ b/GENESIS_RESULT/README.md
@@ -1,0 +1,22 @@
+# Solution Design — Lake arm64 Assembly Conversion
+
+## Scope
+
+This design covers the conversion of the Lake ZMQ message relay from Rust to hand-written AArch64 (arm64) assembly. Lake is a stateless, high-throughput ZMTP 3.0 PULL→PUB relay for the OpenBank platform, currently implemented as ~500 lines of Rust with unsafe FFI bindings to `libzmq`. The conversion targets Linux/arm64, preserving all external contracts (wire protocol, StatsD metrics, systemd integration, configuration interface) while eliminating the Rust compiler and standard library from the runtime.
+
+## Key decisions
+
+*To be populated after Phase 04 (Decisions).*
+
+## How to read this doc set
+
+| Document | Location | Purpose |
+|----------|----------|---------|
+| Architecture | [GENESIS_RESULT/architecture/](architecture/) | High-level architecture diagram and narrative |
+| Prima materia | [GENESIS_SUPPORT/00-prima-materia.md](../GENESIS_SUPPORT/00-prima-materia.md) | Domain distillation and current-to-desired mapping |
+| Constraints | [GENESIS_SUPPORT/01-constraints.md](../GENESIS_SUPPORT/01-constraints.md) | Target environment constraints, invariants, failure scenarios |
+| Topology | [GENESIS_SUPPORT/02-topology.md](../GENESIS_SUPPORT/02-topology.md) | System topology, deployment units, component minimisation |
+| Pattern map | [GENESIS_SUPPORT/03-pattern-map.md](../GENESIS_SUPPORT/03-pattern-map.md) | Pattern inventory, Rust→assembly mappings, unmappable patterns, external contracts |
+| PRDs | [GENESIS_SUPPORT/prd/](../GENESIS_SUPPORT/prd/) | Product Requirements Documents |
+| ADRs | [GENESIS_SUPPORT/adr/](../GENESIS_SUPPORT/adr/) | Architecture Decision Records |
+| Migration | [GENESIS_SUPPORT/migration/](../GENESIS_SUPPORT/migration/) | Migration plan, coexistence, rollback |

--- a/GENESIS_SUPPORT/00-prima-materia.md
+++ b/GENESIS_SUPPORT/00-prima-materia.md
@@ -1,0 +1,46 @@
+# Prima Materia — Lake
+
+Lake is a Rust-based ZMQ message relay for the OpenBank platform. It receives messages on a ZMTP 3.0 PULL socket and fans them out via a PUB socket — a stateless, high-throughput, single-binary service. The architectural intent is to convert the Rust implementation to hand-written arm64 (AArch64) assembly, eliminating the Rust compiler and standard library from the runtime while preserving identical external behaviour, wire protocol compatibility, and operational contracts.
+
+## Domain capabilities
+
+| Domain | Purpose | Cloud touchpoints |
+|--------|---------|-------------------|
+| Message relay | Receives messages from upstream services and fans out to downstream subscribers over ZMTP 3.0 TCP | None |
+| Configuration | Reads runtime parameters (ports, log level, metrics endpoint) from environment variables at startup | None |
+| Process lifecycle | Manages startup, systemd readiness notification, and SIGTERM-based graceful shutdown | None |
+| Metrics emission | Reports message throughput count and memory usage to a StatsD daemon over UDP every second | None |
+| Logging | Writes timestamped, colour-coded log messages to stdout | None |
+| Error handling | Maps ZMQ/POSIX errno codes to human-readable messages for log output | None |
+| Packaging & deployment | Produces Debian .deb packages and Docker images for amd64 and arm64 targets | None (Docker Hub used at CI publish time only) |
+| CI/CD | Multi-arch build, test, package, and publish pipelines across CircleCI, GitHub Actions, and Jenkins | None (all CI-time only) |
+| Black-box testing | BDD integration tests verifying install, configuration, systemd management, metrics, and message relay | None |
+| Performance testing | Throughput benchmarking from 1K to 1B messages measuring relay rate | None |
+
+## Current → desired mapping
+
+| Capability | Current | Desired | ADR | Challenged |
+|-----------|---------|---------|-----|-----------|
+| Core relay loop (PULL→PUB) | Rust unsafe FFI to libzmq (`zmq_msg_recv`/`zmq_msg_send` via `zmq-sys` crate) | arm64 assembly with direct C ABI calls to libzmq | TBD | TBD |
+| ZMQ context management | Rust `Context` struct wrapping `zmq_ctx_new`/`zmq_ctx_set`/`zmq_ctx_term` via `zmq-sys` | arm64 assembly with direct `BL` calls to libzmq functions | TBD | TBD |
+| ZMQ socket management | Rust `Socket` struct wrapping `zmq_socket`/`zmq_bind`/`zmq_connect`/`zmq_setsockopt`/`zmq_close` via `zmq-sys` | arm64 assembly with direct `BL` calls to libzmq functions | TBD | TBD |
+| ZMQ message handling | Rust `Message` struct with `zmq_msg_init`/`zmq_msg_close` via `zmq-sys`, `Drop` for cleanup | arm64 assembly with manual `zmq_msg_t` struct management on stack | TBD | TBD |
+| Error code mapping | Rust `Error` enum mapping `zmq_errno()` to variants with `zmq_strerror()` | arm64 assembly with register-based errno checks and `zmq_strerror()` calls | TBD | TBD |
+| Environment variable configuration | Rust `std::env::var_os` + string parsing (`config.rs`) | arm64 assembly calling libc `getenv` + manual integer parsing | TBD | TBD |
+| Logging to stdout | Rust custom `Logger` implementing `log::Log` trait with `colored` crate, manual date calculation (`logger.rs`) | arm64 assembly writing formatted ANSI-escaped strings via `write` syscall to fd 1 | TBD | TBD |
+| StatsD metrics emission | Rust `statsd` crate (UDP socket, pipeline batching) (`metrics.rs`) | arm64 assembly with raw UDP `socket`/`sendto` syscalls, manual StatsD protocol formatting | TBD | TBD |
+| Memory usage measurement | Rust `procfs` crate reading `/proc/self/stat` RSS (`metrics.rs`, linux-only) | arm64 assembly reading and parsing `/proc/self/stat` via `open`/`read`/`close` syscalls | TBD | TBD |
+| Systemd notification | Rust `UnixDatagram::send_to` to `$NOTIFY_SOCKET` (`program.rs`) | arm64 assembly with `socket`/`sendto` syscalls to Unix datagram | TBD | TBD |
+| Signal handling (SIGTERM) | Rust `libc::signal`/`libc::sigwait`/`libc::sigfillset`/`libc::sigaddset` (`main.rs`) | arm64 assembly with `rt_sigaction`/`rt_sigprocmask`/`rt_sigtimedwait` syscalls | TBD | TBD |
+| Thread management | Rust `std::thread::spawn` (2 threads: relay, metrics) | arm64 assembly using `clone` syscall or libc `pthread_create` | TBD | TBD |
+| Cross-thread atomic coordination | Rust `Arc<AtomicBool>` / `Arc<AtomicUsize>` with `Ordering::Relaxed` | arm64 assembly using `LDAR`/`STLR` (acquire/release) or `LDXR`/`STXR` (exclusive) instructions | TBD | TBD |
+| Graceful shutdown (poison pill) | Rust ZMQ PUSH to loopback PULL port to unblock recv (`relay.rs`) | arm64 assembly with same libzmq `zmq_socket`/`zmq_connect`/`zmq_msg_send` C ABI calls | TBD | TBD |
+| Build system | Cargo + rustc + clang-13/LLD (LTO, release opt-level 3) | GNU `as` assembler + `ld` linker (or `gcc`/`clang` as assembler driver), Makefile | TBD | TBD |
+| Binary stripping | `objcopy --strip-unneeded` / `aarch64-linux-gnu-objcopy --strip-unneeded` | `aarch64-linux-gnu-strip` or `objcopy --strip-all` on assembled binary | TBD | TBD |
+| Debian packaging | `dpkg-buildpackage` with Rust-compiled binary, `lake.install.arm64` | `dpkg-buildpackage` with assembled binary (packaging largely unchanged) | TBD | TBD |
+| Docker image | `arm64v8/debian:sid-slim` + .deb install | `arm64v8/debian:sid-slim` + .deb install (unchanged) | TBD | TBD |
+| Systemd unit files | `lake.service`, `lake-relay.service`, `lake-watcher.path`, `lake-watcher.service` | Unchanged — assembly binary is a drop-in replacement | TBD | TBD |
+| Runtime library dependency | `libzmq5 (>= 4.3~, << 4.4~)`, `libc6` | `libzmq5 (>= 4.3~, << 4.4~)`, `libc6` (unchanged — assembly still links dynamically) | TBD | TBD |
+| CI/CD pipelines | CircleCI + GitHub Actions + Jenkins with Cargo-based build stages | Pipelines updated to use assembler instead of Cargo; test stages unchanged | TBD | TBD |
+| Black-box test suite | Python/Behave BDD tests exercising .deb package via systemd | Unchanged — tests exercise the binary as a black box | TBD | TBD |
+| Performance test suite | Python harness with multiprocessing ZMQ workers | Unchanged — tests exercise the binary externally | TBD | TBD |

--- a/GENESIS_SUPPORT/03-pattern-map.md
+++ b/GENESIS_SUPPORT/03-pattern-map.md
@@ -1,0 +1,81 @@
+# Pattern Map — Lake
+
+Rust (edition 2021, with unsafe FFI to C via `zmq-sys`/`libc` crates) → AArch64 (arm64) assembly (GNU `as` syntax, targeting Linux, linking dynamically against `libzmq.so` and `libc.so`). This translation is non-trivial because Rust provides compile-time memory safety guarantees (ownership, borrowing, lifetimes), a type system with algebraic data types (enums, Result, Option), automatic resource cleanup (Drop trait), and a standard library with managed strings, threading, and atomic types — none of which exist in raw assembly. However, the codebase already operates almost entirely through `unsafe` FFI blocks calling C library functions, which significantly reduces the semantic gap: the Rust code is already closer to C-with-safety-wrappers than to idiomatic safe Rust.
+
+## Pattern inventory
+
+| # | Source pattern | Idiom / example | Frequency | Structural | Risk |
+|---|---------------|----------------|-----------|-----------|------|
+| 1 | Unsafe FFI calls to C library (libzmq) | `zmq_sys::zmq_msg_recv(ptr, puller.sock, 0_i32)` inside `unsafe {}` | 31 instances / 6 files | Yes | Low |
+| 2 | Raw C pointer management (`*mut c_void`) | `pub underlying: *mut c_void` as ZMQ handle | 2 structs, pervasive | Yes | Low |
+| 3 | Manual `Drop` implementations (RAII cleanup) | `impl Drop for Socket { fn drop(&mut self) { zmq_close(self.sock) } }` | 5 implementations | Yes | Medium |
+| 4 | `unsafe impl Send + Sync` for thread-safety marker | `unsafe impl Send for Context {}` | 1 instance | Yes | Low |
+| 5 | `MaybeUninit` + `assume_init` for deferred init | `let mut sigset_memspace = MaybeUninit::uninit(); ... sigset_memspace.assume_init()` | 2 instances | Yes | Low |
+| 6 | `extern "C" fn` callback for signal handler | `extern "C" fn handler(_: libc::c_int) {}` | 1 instance | Yes | Low |
+| 7 | POSIX signal API via libc crate | `libc::signal(SIGTERM, blocking)`, `libc::sigwait(...)` | 4 calls | Yes | Low |
+| 8 | `libc::raise(SIGTERM)` for thread-to-main communication | Child thread raises SIGTERM after loop exit to unblock main | 2 instances | Yes | Low |
+| 9 | Conditional compilation `#[cfg(target_os)]` | `#[cfg(target_os = "linux")] fn mem_bytes()` and `#[cfg(not(target_family = "unix"))]` | 4 cfg blocks | Medium | Low |
+| 10 | Custom logger with manual date/time calculation | `let dayclock = ts % 86400;` — avoids chrono at runtime, computes Y/M/D from epoch | 1 impl (~50 lines) | Medium | Medium |
+| 11 | `Arc<AtomicBool>` cross-thread cancellation flag | `prog.running.clone().store(false, Ordering::Relaxed)` checked in relay and metrics loops | Pervasive (4 files) | Yes | Medium |
+| 12 | `Arc<AtomicUsize>` lock-free accumulator | `self.messages.fetch_add(1, Ordering::Relaxed)` with periodic `swap(0, ...)` drain | 1 instance | Medium | Low |
+| 13 | `std::thread::spawn` for OS-level concurrency | `thread::spawn(move \|\| { ... })` for relay loop and metrics reporter | 2 threads | Yes | High |
+| 14 | `ffi::CString` for C string interop | `CString::new(endpoint.as_bytes()).unwrap()` before passing to `zmq_bind` | 2 instances | Medium | Low |
+| 15 | `mem::transmute` for lifetime extension | `let v: &'static [u8] = mem::transmute(ffi::CStr::from_ptr(s).to_bytes())` | 1 instance | Low | Low |
+| 16 | Rust `Result<T, E>` for error propagation | `fn bind(&self, endpoint: &str) -> Result<(), error::Error>` | ~15 return sites | Yes | Medium |
+| 17 | Rust `match` exhaustive pattern matching | `match self { Error::EACCES => ..., Error::EADDRINUSE => ..., ... }` covering 28 errno variants | ~6 match blocks | Yes | Medium |
+| 18 | Rust `String` / `format!` macro for dynamic strings | `format!("tcp://0.0.0.0:{}", port)` for endpoint construction | ~8 instances | Medium | Medium |
+| 19 | `statsd::Client` UDP pipeline pattern | `let mut pipe = statsd_client.pipeline(); pipe.gauge(...); pipe.count(...); pipe.send(...)` | 1 usage | Medium | High |
+| 20 | `procfs::process::Process::myself().stat().rss` | Linux-specific RSS memory via procfs crate abstractions | 1 usage | Low | Medium |
+| 21 | Rust `println!` / `log::info!` macro expansion | Compile-time string formatting + runtime `Log::log()` dispatch | All files | Medium | Medium |
+| 22 | Closure capture in `thread::spawn(move \|\| {...})` | Moves `ctx`, `pull_port`, `pub_port`, `prog_running`, `metrics` into thread | 2 instances | Yes | High |
+
+## Pattern mapping
+
+| # | Source pattern | Target equivalent | Semantic gap | Mitigation | ADR |
+|---|---------------|------------------|-------------|------------|-----|
+| 1 | Unsafe FFI calls to libzmq | `BL zmq_msg_recv` / `BL zmq_msg_send` — direct C ABI function calls via PLT | None — Rust unsafe FFI already generates identical call sequences | — | TBD |
+| 2 | Raw C pointer management (`*mut c_void`) | Register-based pointer management (e.g. `X19` holds zmq context pointer) | None — assembly is already raw pointer manipulation | — | TBD |
+| 3 | Manual `Drop` (RAII cleanup) | Explicit cleanup code blocks at every exit path; structured as labeled branch targets (e.g. `.Lcleanup_socket:`) | Compiler no longer ensures cleanup runs on all paths — a missed branch skips cleanup and leaks resources | Every function with resources must use a single-exit cleanup pattern; review all branch paths manually | TBD |
+| 4 | `unsafe impl Send + Sync` | Not applicable — no type system in assembly; thread safety is entirely the programmer's responsibility | The compile-time guarantee that data is safe to share across threads disappears | Document which registers/memory hold shared state; use appropriate memory barriers | TBD |
+| 5 | `MaybeUninit` + `assume_init` | Stack-allocated uninitialized memory (`SUB SP, SP, #size`) used directly | None — assembly stack allocation is inherently uninitialized | — | TBD |
+| 6 | `extern "C" fn` signal handler | Label in `.text` section conforming to C calling convention (`X0` = signum) | None — direct equivalent | — | TBD |
+| 7 | POSIX signal API via libc | `BL sigaction` / `SVC #0` with `rt_sigaction` syscall number | None substantive — same libc functions or direct syscalls | Choose between libc calls (simpler) or raw syscalls (no libc dependency for signal path) | TBD |
+| 8 | `libc::raise(SIGTERM)` | `BL raise` or `SVC #0` with `kill` syscall (`getpid` + `kill(pid, SIGTERM)`) | None — direct equivalent | — | TBD |
+| 9 | Conditional compilation `#[cfg]` | Not applicable for single-target arm64 build — linux/arm64 is the only target; dead code eliminated at source level | Source must be written for linux/arm64 only; no macOS `mem_bytes` stub needed | Remove macOS/non-unix code paths entirely; single-platform assembly | TBD |
+| 10 | Custom logger (manual date calc) | Assembly subroutine: `clock_gettime(CLOCK_REALTIME)` → manual epoch-to-YMD conversion → `write(1, buf, len)` | Semantic parity achievable but labour-intensive; ~100 instructions for date formatting | Reimplement the same arithmetic (ts%86400 for time-of-day, year/month loop) in assembly | TBD |
+| 11 | `Arc<AtomicBool>` cross-thread flag | Shared memory location (global `.bss` or heap) accessed with `LDAR`/`STLR` (acquire/release) instructions | Rust `Arc` provides reference-counted shared ownership; assembly uses a global with known lifetime (program duration) — simpler since the flag outlives all threads | Use `.bss` global; no reference counting needed because lifetime is static | TBD |
+| 12 | `Arc<AtomicUsize>` lock-free counter | Shared `.bss` global accessed with `LDXR`/`STXR` (exclusive) for `fetch_add`, `LDAR`/`STLR` for `swap` | Same as #11 — global lifetime simplifies away `Arc` | Use `LDAXR`/`STLXR` loop for atomic increment; `SWP` or `LDXR`/`STXR` for atomic swap-to-zero | TBD |
+| 13 | `std::thread::spawn` | `BL pthread_create` with function pointer + argument pointer, or `clone` syscall with new stack | Rust handles stack allocation, panic unwinding, and thread-local storage automatically; assembly must manually allocate stack (`mmap`), set up function pointer, and clean up on exit | Allocate thread stacks via `mmap(PROT_READ\|PROT_WRITE, MAP_PRIVATE\|MAP_ANONYMOUS\|MAP_STACK)`; use `pthread_create` for simplicity over raw `clone` | TBD |
+| 14 | `ffi::CString` (null-terminated C string) | Null-terminated string literals in `.rodata` section, or stack buffer with null terminator for dynamic strings | None for static strings; for dynamic strings (format with port number), must manually write digits + null terminator into stack buffer | Integer-to-ASCII subroutine for port number formatting | TBD |
+| 15 | `mem::transmute` lifetime extension | Direct pointer use — no lifetime concept in assembly | None — assembly pointers have no lifetime annotations | — | TBD |
+| 16 | `Result<T, E>` error propagation | Register-based convention: `X0` = return value (0 = success, or result), `W0` = -1 on error; check with `CBZ`/`CBNZ`/`CMP` | No compiler enforcement of error checking — a missed check silently ignores errors | Establish and document a calling convention; check return values at every call site | TBD |
+| 17 | `match` exhaustive pattern matching | `CMP`/`B.EQ` chains or jump table (`ADR` + `BR`) for errno dispatch | Compiler no longer verifies exhaustiveness — a missing case falls through silently | Use jump table with default branch for unknown codes; test all errno paths | TBD |
+| 18 | `String` / `format!` dynamic strings | Fixed-size stack buffers + manual `snprintf`-style assembly (digit conversion, `STP`/`STR` to buffer) | Rust `String` grows dynamically; assembly uses fixed buffers that could overflow | Size buffers conservatively (e.g. 128 bytes for `tcp://0.0.0.0:65535\0` is 24 bytes max); assert no overflow | TBD |
+
+## Unmappable patterns
+
+| # | Source pattern | Frequency | Why unmappable | Proposed workaround | Impact |
+|---|---------------|-----------|---------------|--------------------|---------| 
+| U1 | Rust ownership/borrowing/lifetime system | Pervasive (every variable binding) | No assembly equivalent — this is a compile-time analysis with no runtime representation. There is no instruction or mechanism that enforces ownership rules. | Programmer discipline: document ownership of every pointer/register; use single-exit cleanup patterns; never alias mutable state across threads without atomics. No automated verification possible. | **High** — All memory safety guarantees are lost. Use-after-free, double-free, and data races become possible. Mitigated by the fact that the program is small (~500 lines) and the ownership graph is simple (no complex lifetimes). |
+| U2 | Rust type system (enums with data, generics, traits) | ~10 type definitions, `Error` enum (28 variants), `Log` trait impl, `Result<T,E>`, `Option<T>` | No assembly equivalent — types exist only at compile time. Assembly operates on untyped registers and memory. | Establish register/memory layout conventions and document them. Use integer codes for error variants (matching `zmq_errno()` values directly, eliminating the enum translation layer). | **Medium** — Loss of type safety means type confusion bugs are possible. Mitigated by the program's simplicity: only a few "types" exist (ZMQ context pointer, socket pointer, message struct, integer config values). |
+| U3 | Cargo build system + crate ecosystem | 1 Cargo.toml, 6 crate dependencies | No assembly equivalent. Cargo resolves dependencies, manages compilation units, runs tests. Assembly has no package manager or dependency resolution. | Replace with Makefile + GNU `as` + `ld`. All crate functionality (statsd, colored, procfs, log) must be reimplemented in assembly. The only external dependency retained is `libzmq.so` (linked dynamically). | **High** — All Rust library code must be hand-written in assembly. The `statsd` crate (~UDP socket + protocol formatting), `colored` (~ANSI escapes), `procfs` (~/proc parsing), and `log` (~function dispatch) must all be reimplemented. Estimated ~400-600 instructions of new code. |
+| U4 | Rust standard library (`std::thread`, `std::sync::Arc`, `std::env`, `std::io`, `std::ffi`, `std::time`) | Used in every module | No assembly equivalent. The Rust standard library provides platform-abstracted threading, atomics, I/O, environment access, and string handling. | Replace each `std` usage with direct Linux arm64 syscalls or libc C ABI calls: `pthread_create` for threads, `getenv` for env vars, `socket`/`sendto` for UDP, `write` for stdout, `clock_gettime` for time, `open`/`read`/`close` for /proc. | **High** — Every standard library call must be replaced. However, the codebase already uses `libc`/`zmq-sys` for most operations, so the actual unique `std` functionality to reimplement is limited: `thread::spawn` (→ `pthread_create`), `env::var_os` (→ `getenv`), `UnixDatagram` (→ `socket`/`sendto`), `SystemTime` (→ `clock_gettime`). |
+| U5 | Closure capture with `move` semantics in `thread::spawn` | 2 instances (relay thread, metrics thread) | Closures are a compiler-generated anonymous struct containing captured variables, with a generated `call` method. No assembly equivalent. | Pass thread arguments via a struct pointer allocated on the heap (or in `.bss` for program-lifetime data). `pthread_create` accepts a `void* arg` parameter — pack captured values into a struct and pass its address. | **Medium** — Requires manual struct layout for thread arguments. The relay thread needs: `ctx`, `pull_port`, `pub_port`, `prog_running`, `metrics_ptr`. The metrics thread needs: `endpoint_ptr`, `messages_ptr`, `prog_running`. Both are small, fixed sets. |
+| U6 | `statsd::Client` crate (UDP StatsD protocol) | 1 crate, used in metrics thread | No assembly equivalent crate. The `statsd` crate creates a UDP socket, formats StatsD protocol lines (`metric.name:value|type`), batches them in a pipeline, and sends. | Reimplement in assembly: `socket(AF_INET, SOCK_DGRAM, 0)` → `connect` to endpoint → format metric strings into buffer → `sendto`. The StatsD text protocol is trivial: `openbank.lake.message.relayed:N|c\nopenbank.lake.memory.bytes:N|g\n`. Estimated ~80-120 instructions. | **Medium** — The StatsD protocol is simple enough to reimplement. Risk is in endpoint string parsing (`host:port` → `sockaddr_in`). |
+| U7 | `procfs` crate (Linux /proc/self/stat parsing) | 1 crate, 1 call site | No assembly equivalent. The crate reads `/proc/self/stat`, parses the whitespace-delimited fields, and returns structured data. | Reimplement in assembly: `open("/proc/self/stat", O_RDONLY)` → `read` into buffer → scan for 24th space-delimited field (RSS) → multiply by page size (`getauxval(AT_PAGESZ)` or hardcode 4096). Estimated ~60-80 instructions. | **Low** — The parsing is mechanical: skip N fields, read one integer. Single call site. |
+
+## External contract inventory
+
+| # | Contract | Type | Endpoint / schema | Must preserve |
+|---|----------|------|------------------|--------------|
+| 1 | ZMQ PULL socket (message ingress) | ZMTP 3.0 / TCP | `tcp://0.0.0.0:{LAKE_PORT_PULL}` (default 5562) | Yes |
+| 2 | ZMQ PUB socket (message egress) | ZMTP 3.0 / TCP | `tcp://0.0.0.0:{LAKE_PORT_PUB}` (default 5561) | Yes |
+| 3 | ZMQ PUSH poison-pill (shutdown) | ZMTP 3.0 / TCP | `tcp://127.0.0.1:{LAKE_PORT_PULL}` (loopback) | Yes |
+| 4 | StatsD metric: `openbank.lake.message.relayed` | UDP / StatsD count | `{LAKE_STATSD_ENDPOINT}` (default 127.0.0.1:8125) | Yes |
+| 5 | StatsD metric: `openbank.lake.memory.bytes` | UDP / StatsD gauge | `{LAKE_STATSD_ENDPOINT}` (default 127.0.0.1:8125) | Yes |
+| 6 | Systemd notification: `READY=1` | Unix datagram | `$NOTIFY_SOCKET` | Yes |
+| 7 | Systemd notification: `STOPPING=1` | Unix datagram | `$NOTIFY_SOCKET` | Yes |
+| 8 | Environment variables: `LAKE_PORT_PULL`, `LAKE_PORT_PUB`, `LAKE_LOG_LEVEL`, `LAKE_STATSD_ENDPOINT` | Process environment | Read at startup via `getenv` | Yes |
+| 9 | Binary interface: `/usr/bin/lake` (no arguments) | ELF executable | Installed via .deb, started by systemd | Yes |
+| 10 | Exit behaviour: clean shutdown on SIGTERM | POSIX signal | `SIGTERM` → stop relay → close sockets → exit 0 | Yes |
+| 11 | Log output format: `YYYY-MM-DDThh:mm:ssZ LVL [target] message` | stdout | Written to fd 1 | Yes |

--- a/GENESIS_SUPPORT/_raw-findings.md
+++ b/GENESIS_SUPPORT/_raw-findings.md
@@ -1,0 +1,424 @@
+# Phase 01: Discovery — Raw Findings
+
+## 1. Directory Survey
+
+**Project**: `lake` — a ZMQ-backed message relay for the OpenBank platform.
+
+**Language**: Rust (edition 2021, package name `main`, version 0.2.0)
+**Build system**: Cargo (Cargo.toml + Cargo.lock)
+**Package manager**: Cargo (crates.io registry)
+
+**Top-level structure**:
+
+```
+/workspace
+├── services/lake/          # Rust source (8 .rs files)
+│   ├── Cargo.toml
+│   ├── Cargo.lock
+│   └── src/
+│       ├── main.rs         # Entry point, signal handling
+│       ├── config.rs       # Env-based configuration
+│       ├── program.rs      # Lifecycle, systemd notify
+│       ├── relay.rs        # Core ZMQ PULL→PUB relay loop
+│       ├── socket.rs       # ZMQ context/socket wrappers
+│       ├── message.rs      # ZMQ message wrapper
+│       ├── error.rs        # ZMQ errno mapping
+│       └── logger.rs       # Custom log implementation
+├── packaging/              # Debian & Docker packaging
+│   ├── debian/             # .deb control, systemd units, rules
+│   ├── docker/             # amd64 + arm64 Dockerfiles
+│   └── init.conf           # Default env config
+├── bbtest/                 # Black-box tests (Python/Behave)
+├── perf/                   # Performance tests (Python/ZMQ)
+├── dev/lifecycle/          # Build/test/lint/release scripts (bash)
+├── .circleci/config.yml    # CircleCI pipeline
+├── .github/workflows/      # GitHub Actions (health, DevSkim)
+├── .jenkins/               # Jenkins pipeline (Groovy)
+├── Makefile                # Top-level orchestration
+├── docker-compose.yml      # Dev/CI service definitions
+└── README.md
+```
+
+**Infrastructure artifacts**: Dockerfiles (amd64, arm64), docker-compose.yml, systemd unit files (lake.service, lake-relay.service, lake-watcher.path, lake-watcher.service), Debian packaging (control, rules, install files), CircleCI config, GitHub Actions workflows, Jenkins Groovyscript.
+
+---
+
+## 2. Dependency Scan
+
+### Direct Rust dependencies (Cargo.toml)
+
+| Crate | Version | Classification |
+|-------|---------|---------------|
+| `zmq-sys` | 0.11.0 | **Messaging** — raw FFI bindings to libzmq (C library) |
+| `libc` | 0.2.154 | **System** — POSIX/libc FFI (signals, socket types) |
+| `statsd` | 0.16.0 | **Metrics** — StatsD UDP client |
+| `log` | 0.4.18 | **General** — logging facade |
+| `colored` | 1.6.1 | **General** — terminal color output |
+| `procfs` | 0.15.1 | **System** — Linux /proc filesystem reader (linux-only, conditional) |
+
+### Key transitive dependencies (from Cargo.lock)
+
+| Crate | Role |
+|-------|------|
+| `metadeps` / `pkg-config` | Build-time: locates system libzmq via pkg-config |
+| `chrono` | Used by `procfs` for timestamps |
+| `rand` | Used by `statsd` for sampling |
+| `cc` / `cxx` / `cxx-build` | Build-time: C/C++ compilation (transitive from procfs/chrono) |
+
+### System library dependency
+
+| Library | Version constraint | Source |
+|---------|-------------------|--------|
+| `libzmq5` | >= 4.3, < 4.4 | `packaging/debian/control` Depends field |
+
+**Classification summary**: No cloud SDKs. No database drivers. No auth libraries. All dependencies are system-level or messaging-related. The project links dynamically against `libzmq5` (a C library).
+
+---
+
+## 3. Cloud Touchpoint Grep
+
+**Result**: No cloud vendor SDKs, no cloud-specific environment variables, no cloud service references found anywhere in the Rust source, configuration, or packaging. The project is already vendor-independent.
+
+The only external service reference is:
+- **Docker Hub** (`docker.io/openbank/lake`) — for image publishing (CI/CD only, not runtime)
+- **GitHub Packages** (`docker.pkg.github.com`) — for image publishing (CI/CD only, not runtime)
+- **GitHub API** — for release asset uploading (CI/CD only)
+- **Artifactory** — referenced in Jenkins pipeline for artifact storage (CI/CD only)
+
+**Runtime cloud touchpoints**: None.
+
+---
+
+## 4. Communication Patterns
+
+### Core relay pattern
+
+The system implements a single communication pattern: **ZMQ PULL→PUB relay**.
+
+- **PULL socket** binds to `tcp://0.0.0.0:{LAKE_PORT_PULL}` (default 5562). Receives messages from upstream services (ZMQ PUSH clients).
+- **PUB socket** binds to `tcp://0.0.0.0:{LAKE_PORT_PUB}` (default 5561). Publishes messages to downstream subscribers (ZMQ SUB clients).
+- **Protocol**: ZMTP 3.0 with NULL security mechanism (no encryption, no auth).
+- **Message format**: Opaque binary blobs — the relay does not inspect or transform message content. Topic-based subscription is used by subscribers (first space-delimited token is the topic).
+
+### Socket options
+
+| Socket | Option | Value | Purpose |
+|--------|--------|-------|---------|
+| PULL | ZMQ_CONFLATE | 0 | Keep all messages (no conflation) |
+| PULL | ZMQ_IMMEDIATE | 1 | Only queue to completed connections |
+| PULL | ZMQ_LINGER | 0 | Discard pending on close |
+| PULL | ZMQ_RCVHWM | 0 | Unlimited receive high-water mark |
+| PUB | ZMQ_CONFLATE | 0 | Keep all messages |
+| PUB | ZMQ_IMMEDIATE | 1 | Only queue to completed connections |
+| PUB | ZMQ_LINGER | 0 | Discard pending on close |
+| PUB | ZMQ_SNDHWM | 0 | Unlimited send high-water mark |
+| PUB | ZMQ_XPUB_NODROP | 1 | Do not silently drop messages |
+
+### Graceful shutdown
+
+A poison-pill mechanism: on shutdown, a ZMQ PUSH socket connects to the PULL port and sends an empty message to unblock the blocking `zmq_msg_recv` in the relay loop. After the relay thread terminates, `SIGTERM` is raised.
+
+### Systemd notification
+
+The program sends `READY=1` and `STOPPING=1` to the systemd `NOTIFY_SOCKET` via Unix datagram, enabling `Type=notify` service management.
+
+---
+
+## 5. Storage Patterns
+
+**Result**: No databases, no object storage, no caching layers, no session stores. The system is purely a stateless message relay. No data is persisted.
+
+---
+
+## 6. Authentication & Authorization
+
+**Result**: ZMQ NULL mechanism — no authentication or encryption. No identity providers, no token handling, no RBAC/ABAC. The relay accepts all connections on the bound ports.
+
+---
+
+## 7. Configuration & Secrets
+
+### Environment variables
+
+| Variable | Default | Purpose | Source |
+|----------|---------|---------|--------|
+| `LAKE_PORT_PULL` | 5562 | ZMQ PULL socket bind port | `config.rs`, `init.conf` |
+| `LAKE_PORT_PUB` | 5561 | ZMQ PUB socket bind port | `config.rs`, `init.conf` |
+| `LAKE_LOG_LEVEL` | INFO | Log verbosity (DEBUG/INFO/WARN/ERROR) | `config.rs`, `init.conf` |
+| `LAKE_STATSD_ENDPOINT` | 127.0.0.1:8125 | StatsD daemon address | `config.rs`, `init.conf` |
+| `NOTIFY_SOCKET` | (system) | Systemd notification socket | `program.rs` |
+
+### Config file
+
+`/etc/lake/conf.d/init.conf` — sourced by systemd as `EnvironmentFile`. Contains key=value pairs for all `LAKE_*` variables. A systemd `.path` unit watches this directory for changes and triggers restart.
+
+### Secrets
+
+No secrets managed. No secret manager integration. No TLS certificates.
+
+---
+
+## 8. Infrastructure
+
+### Systemd units
+
+| Unit | Type | Purpose |
+|------|------|---------|
+| `lake.service` | oneshot | Control group parent |
+| `lake-relay.service` | notify | Core relay process (`/usr/bin/lake`) |
+| `lake-watcher.path` | path | Watches `/etc/lake/conf.d` for changes |
+| `lake-watcher.service` | simple | Restarts `lake.service` on config change |
+
+Key service properties: `Restart=always`, `RestartSec=0`, `LimitNOFILE=1048576`, `LimitNPROC=infinity`, `KillSignal=SIGTERM`, `TimeoutStopSec=3`.
+
+### Debian packaging
+
+- Package name: `lake`
+- Architecture: `any` (built for amd64 and arm64)
+- Runtime dependency: `libzmq5 (>= 4.3~, << 4.4~)`, `libc6`
+- Binary installed to `/usr/bin/lake` (renamed from `lake-linux-{arch}`)
+- Config installed to `/etc/lake/conf.d/init.conf`
+
+### Docker images
+
+- `amd64`: Based on `amd64/debian:sid-slim`, installs the .deb package
+- `arm64`: Based on `arm64v8/debian:sid-slim`, installs the .deb package
+- Both use `ENTRYPOINT ["lake"]`
+
+### Build toolchain
+
+- Rust compiler via custom Docker image (`jancajthaml/rust:{arch}`)
+- Cross-compilation: clang-13 linker, LLD, LTO enabled
+- Strip: `objcopy --strip-unneeded` (amd64), `aarch64-linux-gnu-objcopy --strip-unneeded` (arm64)
+- Release profile: `opt-level = 3`
+
+### CI/CD pipelines
+
+| Platform | Purpose | Architectures |
+|----------|---------|---------------|
+| CircleCI | Primary CI: unit test, compile, debian package, docker package, bbtest, publish, release | amd64 + arm64 |
+| GitHub Actions (health.yml) | From-scratch build + unit test on ubuntu-latest | amd64 only |
+| GitHub Actions (dev-skim.yml) | Security scanning (DevSkim) | N/A |
+| Jenkins | Alternative CI with Artifactory publishing | amd64 (primarily) |
+
+### Multi-arch build
+
+The project already builds for both amd64 and arm64. The Makefile auto-detects architecture via `uname -m`. CircleCI uses `machine-arm64` and `machine-amd64` executors for native builds.
+
+---
+
+## 9. Multi-tenancy Signals
+
+**Result**: No multi-tenancy. No tenant models, no database switching, no subdomain routing. The relay is a single-purpose, single-instance service.
+
+---
+
+## 10. Language and Framework Patterns
+
+### Rust-specific patterns
+
+| Pattern | Type | Where used | Frequency | Structural |
+|---------|------|-----------|-----------|-----------|
+| Unsafe FFI calls to zmq-sys | FFI/unsafe | `relay.rs`, `socket.rs`, `message.rs`, `error.rs`, `main.rs` | 31 instances across 6 files | Yes — the entire relay loop and all socket operations are unsafe FFI |
+| Raw pointer management (`*mut c_void`) | Unsafe memory | `socket.rs` (Context, Socket structs) | Pervasive in socket.rs | Yes — ZMQ handles are raw C pointers |
+| Manual `Drop` implementations | RAII | `socket.rs`, `relay.rs`, `message.rs`, `program.rs` | 5 Drop impls | Yes — resource cleanup for ZMQ contexts, sockets, messages, relay thread |
+| `unsafe impl Send + Sync` for Context | Concurrency marker | `socket.rs:10-11` | 1 instance | Yes — enables cross-thread ZMQ context sharing |
+| `MaybeUninit` for signal handling | Unsafe init | `main.rs:41-54` | 2 instances | Yes — signal set and signum initialization |
+| `extern "C" fn` signal handler | FFI callback | `main.rs:58` | 1 instance | Yes — SIGTERM handler |
+| `libc::signal`, `libc::sigwait`, `libc::sigfillset`, `libc::sigaddset` | POSIX signal API | `main.rs:34-55` | 4 calls | Yes — signal-based lifecycle management |
+| `libc::raise(SIGTERM)` for self-termination | POSIX signal | `relay.rs:97`, `metrics.rs:64` | 2 instances | Yes — thread-to-main-thread communication |
+| Conditional compilation (`#[cfg(target_os)]`) | Platform dispatch | `metrics.rs:79-95`, `program.rs:37-57` | 2 modules | Medium — platform-specific memory reading and systemd notify |
+| Custom logger with manual timestamp formatting | No-framework logging | `logger.rs` (entire file) | 1 implementation | Yes — avoids chrono dependency at runtime, manual date calculation |
+| `Arc<AtomicBool>` for cross-thread cancellation | Atomic coordination | `main.rs`, `relay.rs`, `metrics.rs`, `program.rs` | Pervasive | Yes — the shutdown coordination mechanism |
+| `Arc<AtomicUsize>` for lock-free counter | Atomic metrics | `metrics.rs:12` | 1 instance | Medium — metrics accumulation |
+| `thread::spawn` for concurrency | OS threads | `relay.rs:53`, `metrics.rs:38` | 2 threads | Yes — relay loop and metrics reporting run in separate OS threads |
+| `zmq_sys::zmq_msg_t::default()` for zero-init | FFI struct init | `message.rs:20` | 1 instance | Medium — relies on Default trait for C struct |
+| `mem::transmute` for lifetime extension | Unsafe cast | `error.rs:123` | 1 instance | Low — casts CStr bytes to static lifetime |
+
+### External library conventions
+
+| Convention | Where | Notes |
+|-----------|-------|-------|
+| `statsd::Client` UDP pipeline | `metrics.rs` | Fire-and-forget UDP metrics every 1 second |
+| `log` facade macros | All source files | `log::info!`, `log::debug!`, `log::error!`, `log::warn!` |
+| `colored` for terminal output | `logger.rs` | Color-coded log levels |
+| `procfs::process::Process::myself()` | `metrics.rs` | Linux-only memory measurement via /proc |
+
+---
+
+## 11. External Contract Inventory
+
+### ZMQ wire protocol (ZMTP 3.0)
+
+| Contract | Type | Endpoint / schema | Where defined |
+|----------|------|------------------|--------------|
+| PULL socket (message ingress) | ZMQ/ZMTP 3.0 PULL | `tcp://0.0.0.0:5562` | `relay.rs:128`, `config.rs:19` |
+| PUB socket (message egress) | ZMQ/ZMTP 3.0 PUB | `tcp://0.0.0.0:5561` | `relay.rs:162`, `config.rs:20` |
+| Shutdown poison pill | ZMQ/ZMTP 3.0 PUSH→PULL | `tcp://127.0.0.1:{pull_port}` | `relay.rs:24` |
+| StatsD metrics | UDP/StatsD | `127.0.0.1:8125` | `metrics.rs:39`, `config.rs:22` |
+| Systemd notification | Unix datagram | `$NOTIFY_SOCKET` | `program.rs:38-52` |
+
+### StatsD metrics
+
+| Metric | Type | Description |
+|--------|------|-------------|
+| `openbank.lake.message.relayed` | count | Messages relayed per second |
+| `openbank.lake.memory.bytes` | gauge | RSS memory in bytes |
+
+### CLI interface
+
+| Command | Arguments | Description |
+|---------|-----------|-------------|
+| `lake` | (none — configured via env) | Starts the relay daemon |
+
+---
+
+## 12. Test Architecture
+
+| Aspect | Finding |
+|--------|---------|
+| **Unit test framework** | Cargo's built-in `#[test]` (invoked via `cargo test`). No unit tests found in the source files — the codebase has zero Rust test functions. |
+| **Black-box test framework** | Python 3 + Behave (BDD/Gherkin). 6 feature files, ~15 scenarios. |
+| **Black-box test runner** | `bbtest/main.py` — orchestrates Behave, converts results to Cucumber JSON, then to JUnit XML. |
+| **Black-box test helpers** | `openbank_testkit` (Shell, Package, Platform, StatsdMock), `systemd.journal` (journalctl reader), custom `ZMQHelper` (push/subscribe client), `eventually` (polling retry decorator). |
+| **Black-box test categories** | Install/uninstall (.deb), systemd unit management, configuration, metrics collection, message relay order. |
+| **Performance test framework** | Python 3 custom harness (`perf/main.py`). Pushes increasing message volumes (1K to 1B) and measures throughput. |
+| **Performance test helpers** | `Publisher` (multiprocessing ZMQ push+subscribe workers), `ApplianceManager` (systemd-based service lifecycle), `Metrics`/`Graph` (JSON metrics + matplotlib plotting). |
+| **Test execution environment** | Docker container (`jancajthaml/bbtest:{arch}`), runs systemd inside container, installs .deb, exercises real systemd service lifecycle. |
+| **Test distribution** | 0 unit tests, ~15 black-box integration tests, 1 performance test suite. |
+
+---
+
+## 13. Module Dependency Mapping
+
+The Rust source is a single flat module structure (no sub-crates, no workspace):
+
+```
+main.rs (entry point)
+├── config.rs     (leaf — no internal deps)
+├── error.rs      (leaf — depends only on zmq_sys)
+├── logger.rs     (leaf — depends only on colored, log)
+├── message.rs    (depends on: error)
+├── metrics.rs    (depends on: config)
+├── program.rs    (depends on: config, logger)
+├── socket.rs     (depends on: error)
+└── relay.rs      (depends on: config, error, message, metrics, socket)
+```
+
+**Dependency graph**:
+
+```
+config ←── program
+  │           └── logger
+  │
+  ├── metrics
+  │
+  └── relay ──→ message ──→ error
+       │                     ↑
+       └──→ socket ──────────┘
+```
+
+**Leaf modules** (zero internal dependants): `logger`, `error`, `config`
+**Core modules** (most dependants): `relay` (depends on 5 other modules)
+**Circular dependencies**: None
+
+### External module dependencies
+
+| Rust module | External crate dependencies |
+|------------|---------------------------|
+| `config.rs` | `std::env` |
+| `error.rs` | `zmq_sys::errno`, `zmq_sys::zmq_strerror`, `std::ffi`, `std::fmt`, `std::mem`, `std::str` |
+| `logger.rs` | `colored::Colorize`, `log::{Level, LevelFilter, Log, Metadata, Record, SetLoggerError}`, `std::time::SystemTime` |
+| `message.rs` | `zmq_sys::zmq_msg_t`, `zmq_sys::zmq_msg_init`, `zmq_sys::zmq_msg_close` |
+| `metrics.rs` | `statsd::Client`, `std::sync::atomic`, `std::thread`, `std::time::Duration`, `procfs` (linux) |
+| `program.rs` | `std::os::unix::net::UnixDatagram`, `std::sync::atomic`, `std::env`, `std::io`, `log` |
+| `relay.rs` | `zmq_sys::zmq_msg_recv`, `zmq_sys::zmq_msg_send`, `zmq_sys::ZMQ_PULL`, `zmq_sys::ZMQ_PUB`, `zmq_sys::ZMQ_PUSH`, `std::thread`, `std::sync::atomic`, `libc::raise`, `libc::SIGTERM` |
+| `socket.rs` | `zmq_sys::zmq_ctx_new`, `zmq_sys::zmq_ctx_set`, `zmq_sys::zmq_ctx_term`, `zmq_sys::zmq_socket`, `zmq_sys::zmq_bind`, `zmq_sys::zmq_connect`, `zmq_sys::zmq_setsockopt`, `zmq_sys::zmq_close`, `zmq_sys::zmq_errno`, `libc::c_void`, `libc::size_t`, `std::ffi`, `std::mem` |
+| `main.rs` | `std::mem`, `std::sync::atomic::Ordering`, `libc::signal`, `libc::sigwait`, `libc::sigfillset`, `libc::sigaddset`, `libc::SIGTERM`, `libc::sigset_t`, `libc::sighandler_t`, `libc::c_int`, `libc::c_void` |
+
+---
+
+## Domain Capabilities Table
+
+| Domain | Key files / classes | Purpose | Cloud touchpoints |
+|--------|-------------------|---------|-------------------|
+| Message relay | `relay.rs`, `socket.rs`, `message.rs` | Receives messages on a PULL socket and fans out via PUB socket over ZMTP 3.0 TCP | None |
+| Configuration | `config.rs`, `packaging/init.conf` | Environment-variable-based configuration for ports, log level, and metrics endpoint | None |
+| Lifecycle management | `program.rs`, `main.rs` | Process startup, systemd notification, SIGTERM-based graceful shutdown | None |
+| Metrics | `metrics.rs` | Emits message relay count and memory usage to a StatsD endpoint every second | None |
+| Logging | `logger.rs` | Custom colored log output with manual timestamp formatting to stdout | None |
+| Error handling | `error.rs` | Maps ZMQ errno codes to Rust enum variants with human-readable messages | None |
+| Packaging & deployment | `packaging/`, `Makefile`, `docker-compose.yml` | Debian .deb packaging, Docker images, systemd service units for amd64 and arm64 | Docker Hub (CI publish only) |
+| CI/CD | `.circleci/`, `.github/workflows/`, `.jenkins/` | Multi-arch build, test, package, publish pipelines | GitHub Actions, CircleCI, Docker Hub, GitHub Packages (CI only) |
+| Black-box testing | `bbtest/` | BDD tests for install, config, management, metrics, and relay behaviour | None |
+| Performance testing | `perf/` | Throughput benchmarking up to 1B messages | None |
+
+## Communication Patterns Table
+
+| Pattern | Protocol | Where used | Cloud dependency |
+|---------|----------|-----------|-----------------|
+| ZMQ PULL (message ingress) | ZMTP 3.0 over TCP | `relay.rs:107-134` | None |
+| ZMQ PUB (message egress) | ZMTP 3.0 over TCP | `relay.rs:137-169` | None |
+| ZMQ PUSH (shutdown signal) | ZMTP 3.0 over TCP (loopback) | `relay.rs:21-31` | None |
+| StatsD metrics emission | UDP | `metrics.rs:38-65` | None |
+| Systemd notify | Unix datagram | `program.rs:38-52` | None |
+| Signal handling (SIGTERM) | POSIX signals | `main.rs:34-58` | None |
+
+## Language Patterns Table
+
+| Pattern | Type | Where used | Frequency | Structural |
+|---------|------|-----------|-----------|-----------|
+| Unsafe FFI calls to C library (libzmq) | FFI/unsafe | `relay.rs`, `socket.rs`, `message.rs`, `error.rs`, `main.rs` | 31 instances / 6 files | Yes |
+| Raw C pointer management (`*mut c_void`) | Unsafe memory | `socket.rs` (Context.underlying, Socket.sock) | 2 structs, pervasive use | Yes |
+| Manual `Drop` for RAII cleanup | Resource management | `socket.rs`, `relay.rs`, `message.rs`, `program.rs` | 5 implementations | Yes |
+| `unsafe impl Send + Sync` | Concurrency safety | `socket.rs:10-11` | 1 instance | Yes |
+| `MaybeUninit` + `assume_init` | Unsafe initialization | `main.rs:41-54` | 2 instances | Yes |
+| `extern "C" fn` callback | FFI callback | `main.rs:58` | 1 instance | Yes |
+| POSIX signal API via libc | System interface | `main.rs:34-55` | 4 libc calls | Yes |
+| `libc::raise(SIGTERM)` for thread self-kill | System interface | `relay.rs:97`, `metrics.rs:64` | 2 instances | Yes |
+| Conditional compilation (`#[cfg(...)]`) | Platform dispatch | `metrics.rs`, `program.rs` | 4 cfg blocks | Medium |
+| Manual date/time formatting (no chrono at runtime) | Custom implementation | `logger.rs:55-100` | 1 implementation | Medium |
+| `Arc<AtomicBool>` cross-thread cancellation | Lock-free coordination | `main.rs`, `relay.rs`, `metrics.rs`, `program.rs` | Pervasive | Yes |
+| `Arc<AtomicUsize>` lock-free counter | Atomic metrics | `metrics.rs:12` | 1 instance | Medium |
+| `thread::spawn` OS-level concurrency | Threading | `relay.rs:53`, `metrics.rs:38` | 2 threads | Yes |
+| `mem::transmute` lifetime extension | Unsafe cast | `error.rs:123` | 1 instance | Low |
+| `ffi::CString` for C string interop | FFI | `socket.rs:63,71` | 2 instances | Medium |
+
+## External Contracts Table
+
+| Contract | Type | Endpoint / schema | Where defined |
+|----------|------|------------------|--------------|
+| ZMQ PULL ingress | ZMTP 3.0 / TCP | `tcp://0.0.0.0:{LAKE_PORT_PULL}` (default 5562) | `relay.rs:128`, `config.rs:19` |
+| ZMQ PUB egress | ZMTP 3.0 / TCP | `tcp://0.0.0.0:{LAKE_PORT_PUB}` (default 5561) | `relay.rs:162`, `config.rs:20` |
+| StatsD metrics | UDP / StatsD protocol | `{LAKE_STATSD_ENDPOINT}` (default 127.0.0.1:8125) | `metrics.rs:39`, `config.rs:22` |
+| Systemd notification | Unix datagram | `$NOTIFY_SOCKET` | `program.rs:38-52` |
+| `lake` CLI | Binary executable | `/usr/bin/lake` (no arguments, env-configured) | `packaging/debian/lake-relay.service:12` |
+| StatsD metric: `openbank.lake.message.relayed` | StatsD count | Per-second relay count | `metrics.rs:57` |
+| StatsD metric: `openbank.lake.memory.bytes` | StatsD gauge | RSS memory bytes | `metrics.rs:55` |
+
+## Test Architecture Table
+
+| Aspect | Finding |
+|--------|---------|
+| Unit test framework | Cargo built-in `#[test]` — **zero unit tests exist** |
+| Black-box framework | Python 3 / Behave (Gherkin BDD) |
+| Black-box scenarios | ~15 across 6 feature files (install, uninstall, config, management, metrics, relay) |
+| Performance framework | Custom Python harness with multiprocessing ZMQ workers |
+| Test execution | Docker container with systemd, installs .deb, exercises real service lifecycle |
+| Test dependencies | `openbank_testkit`, `behave`, `behave2cucumber`, `zmq` (pyzmq), `systemd.journal` |
+| Coverage | No code coverage tooling configured |
+| CI test stages | Unit test → blackbox test (blocking), performance test (optional) |
+
+## Module Dependency Graph
+
+```
+config (leaf)
+├──→ program ──→ logger (leaf)
+├──→ metrics
+└──→ relay ──→ message ──→ error (leaf)
+      └──→ socket ──→ error (leaf)
+```
+
+Leaf modules: `config`, `logger`, `error`
+Core module: `relay` (5 internal dependencies)
+Cycles: None


### PR DESCRIPTION
Generate raw findings for the `lake` Rust project to establish the baseline for architectural conversion to arm64 assembly.

The `lake` project is a stateless ZMQ message relay with heavy use of `unsafe` FFI calls to `libzmq5`. It has no cloud touchpoints and already supports multi-arch builds. Key patterns include raw C pointers, manual `Drop` implementations, and `libc` signal handling, which are critical for the arm64 assembly conversion. Testing is primarily black-box BDD and performance-focused.

---
<p><a href="https://cursor.com/background-agent?bcId=bc-a6fa7373-5e04-47c2-a188-a98cd9a8ecb0"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-a6fa7373-5e04-47c2-a188-a98cd9a8ecb0"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a></p>

